### PR TITLE
Adding option to use External Image Proxy to Elkarte

### DIFF
--- a/_posts/2018-03-12-ExtImageProxy.MD
+++ b/_posts/2018-03-12-ExtImageProxy.MD
@@ -1,0 +1,33 @@
+---
+layout: post
+title: "External Image Proxy"
+pkid: "tinoest:ExtImageProxy"
+category: enhancement
+date: 2018-03-17
+comments: false
+short: "Use images.weserv.nl to serve up http images"
+license: BSD 3
+version: 1.0.0
+allhooks: yes
+elkversion: 1.1
+support: https://github.com/tinoest/ElkExtImageProxy 
+bugs: https://github.com/tinoest/ElkExtImageProxy/issues
+author: tinoest
+thumbnail:
+download: https://github.com/tinoest/ElkExtImageProxy/archive/1.0.0.tar.gz
+images:
+---
+
+## Introduction:
+This allows you to utilise the images.weserv.nl service which is an image cache & resize proxy
+
+## Features:
+ - Utilise Images.weserv.nl to serve all http images
+
+## Installation:
+Simply install the package to install this addon on ElkArte. It is enabled via the Addon Settings
+
+{% include install_std.MD %}
+
+### License:
+{% include license.MD param="BSD 3" %}


### PR DESCRIPTION
Adds the option to use the https://images.weserv.nl/ service to serve http images. 